### PR TITLE
Update vi-mode key bindings to work with Tmux 2.4.

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -33,12 +33,12 @@ setw -g xterm-keys
 setw -g mode-keys vi
 
 # Setup 'v' to being selection as in Vim
-bind-key -t vi-copy v begin-selection
-bind-key -t vi-copy y copy-pipe "reattach-to-user-namespace pbcopy"
+bind-key -Tcopy-mode-vi v send -X begin-selection
+bind-key -Tcopy-mode-vi y send -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
 
 # Update default binding of `Enter` to also use copy-pipe
-unbind -t vi-copy Enter
-bind-key -t vi-copy Enter copy-pipe "reattach-to-user-namespace pbcopy"
+unbind -Tcopy-mode-vi Enter
+bind-key -Tcopy-mode-vi Enter send -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
 
 #select panes with <Prefix> h, j, k, l
 bind h select-pane -L


### PR DESCRIPTION
* Reference: tmux/tmux#592